### PR TITLE
Fix textual cell error and refactor game

### DIFF
--- a/src/ui_textual.py
+++ b/src/ui_textual.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Optional, Tuple
+from typing import Optional
 
 from textual.app import App, ComposeResult
 from textual.reactive import reactive
 from textual.widgets import Static, Input, DataTable
 from textual.containers import Horizontal, Vertical, Container
-from textual import events
 
 from .game import Game
 from .ai import CaroAI
@@ -135,7 +134,7 @@ class CaroApp(App):
         self.header.id = "header"
 
         # Main area with board and sidebar
-        self.board_table = DataTable(zebra_stripes=False, cursor_type="row")
+        self.board_table = DataTable(zebra_stripes=False, cursor_type="cell")
         left = Container(self.board_table, id="left")
 
         self.status_panel = InfoPanel(classes="panel")
@@ -172,7 +171,6 @@ class CaroApp(App):
         self.board_table.clear(columns=True)
         self.row_keys = []
         self.col_keys = []
-        self.board_table.cursor_type = "cell"
         # First column header blank, others 1..N
         blank_key = self.board_table.add_column(" ")
         self.col_keys.append(blank_key)


### PR DESCRIPTION
Fixes `CellDoesNotExist` error in Textual UI by using stable row/column keys for DataTable updates and refines the UI with a concise help panel.

The `CellDoesNotExist` error stemmed from `textual.widgets.DataTable` expecting `RowKey` and `ColumnKey` for cell updates, while the previous code was passing numeric indices. This PR ensures that all cell manipulations and click event mappings correctly use the stable keys generated by `DataTable.add_column` and `DataTable.add_row`, preventing the runtime error. Additionally, the UI has been streamlined and a user-friendly help guide integrated.

---
<a href="https://cursor.com/background-agent?bcId=bc-4155b384-6b8d-4e1e-ad9f-44e436b5d94d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4155b384-6b8d-4e1e-ad9f-44e436b5d94d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

